### PR TITLE
Kie deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+target
+*.iml

--- a/Translator/pom.xml
+++ b/Translator/pom.xml
@@ -54,8 +54,8 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>16</maven.compiler.source>
-        <maven.compiler.target>16</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -121,7 +121,7 @@
         </profile>
     </profiles>
 
-    <distributionManagement>
+    <!-- <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
             <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
@@ -130,6 +130,6 @@
             <id>ossrh</id>
             <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
-    </distributionManagement>
+    </distributionManagement> -->
 
 </project>

--- a/Translator/pom.xml
+++ b/Translator/pom.xml
@@ -121,6 +121,8 @@
         </profile>
     </profiles>
 
+    <!-- Disabled due to issues with kie workbench -->
+    <!-- uncomment before calling mvn deploy to deploy to central repository -->
     <!-- <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>


### PR DESCRIPTION
Due to issues with kie workbench the translator can't use java 12+ and contain the deployment info. I commnted out the deployment info from pom and downgraded the project to java 11. This version of the translator can be uploaded to kie workbench and used in rule creation.